### PR TITLE
ユーザー情報編集機能の追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,2 @@
+class UsersController < ApplicationController
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,7 @@
 class UsersController < ApplicationController
+  def edit
+  end
+
+  def update
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,16 @@
 class UsersController < ApplicationController
+  # 本人以外はeditアクションとupdateアクションを実行できないようにする
+  before_action :correct_user, only: [:edit, :update]
+
   def edit
   end
 
   def update
+  end
+
+  private
+  def correct_user
+    @user = User.find(params[:id])
+    redirect_to(root_url) unless @user == current_user
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,8 +6,11 @@ class UsersController < ApplicationController
   end
 
   def update
-    @user.update(user_params)
-    redirect_to(root_url)
+    if @user.update(user_params)
+      redirect_to(root_url)
+    else
+      render "edit"
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,9 +6,8 @@ class UsersController < ApplicationController
   end
 
   def update
-    user = User.find(params[:id])
-    user.update(user_params)
-    redirect_to controller: :messages, action: :index
+    @user.update(user_params)
+    redirect_to(root_url)
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,11 +6,18 @@ class UsersController < ApplicationController
   end
 
   def update
+    user = User.find(params[:id])
+    user.update(user_params)
+    redirect_to controller: :messages, action: :index
   end
 
   private
   def correct_user
     @user = User.find(params[:id])
     redirect_to(root_url) unless @user == current_user
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,11 +6,17 @@ class UsersController < ApplicationController
   end
 
   def update
+    user = User.find(params[:id])
+    user.update(user_params)
   end
 
   private
   def correct_user
     @user = User.find(params[:id])
     redirect_to(root_url) unless @user == current_user
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,16 +7,16 @@ class UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to(root_url)
+      redirect_to :root
     else
-      render "edit"
+      render :edit
     end
   end
 
   private
   def correct_user
     @user = User.find(params[:id])
-    redirect_to(root_url) unless @user == current_user
+    redirect_to :root unless @user == current_user
   end
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,17 +6,11 @@ class UsersController < ApplicationController
   end
 
   def update
-    user = User.find(params[:id])
-    user.update(user_params)
   end
 
   private
   def correct_user
     @user = User.find(params[:id])
     redirect_to(root_url) unless @user == current_user
-  end
-
-  def user_params
-    params.require(:user).permit(:name, :email)
   end
 end

--- a/app/views/messages/_side.html.haml
+++ b/app/views/messages/_side.html.haml
@@ -3,7 +3,7 @@
     .user
       %span.user__name tsuruta
       / ユーザー情報編集ページへのリンク。if以降は非ログインユーザーに対するリダイレクト処理が実装できるまで仮置き
-      = link_to "", edit_user_path(current_user.id), method: :GET, class: ["fa", "fa-cog", "user__option"] if user_signed_in?
+      = link_to "", edit_user_path(current_user), class: ["fa", "fa-cog", "user__option"] if user_signed_in?
       %a.fa.fa-pencil-square-o.user__option(href="#" title="")
   .side__body
     %ul.groups

--- a/app/views/messages/_side.html.haml
+++ b/app/views/messages/_side.html.haml
@@ -2,7 +2,7 @@
   .side__header
     .user
       %span.user__name tsuruta
-      %a.fa.fa-cog.user__option(href="#" title="")
+      = link_to "", edit_user_path(current_user.id), method: :GET, class: ["fa", "fa-cog", "user__option"]
       %a.fa.fa-pencil-square-o.user__option(href="#" title="")
   .side__body
     %ul.groups

--- a/app/views/messages/_side.html.haml
+++ b/app/views/messages/_side.html.haml
@@ -2,7 +2,8 @@
   .side__header
     .user
       %span.user__name tsuruta
-      = link_to "", edit_user_path(current_user.id), method: :GET, class: ["fa", "fa-cog", "user__option"]
+      / ユーザー情報編集ページへのリンク。if以降は非ログインユーザーに対するリダイレクト処理が実装できるまで仮置き
+      = link_to "", edit_user_path(current_user.id), method: :GET, class: ["fa", "fa-cog", "user__option"] if user_signed_in?
       %a.fa.fa-pencil-square-o.user__option(href="#" title="")
   .side__body
     %ul.groups

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
+  resources :users, only: [:edit, :update]
   root    "messages#index"
 end


### PR DESCRIPTION
# WHAT
- ユーザー情報を編集するビューを追加し（指定のもの）、そこへのリンクを設置
- Usersコントローラを作成して情報編集のためのアクションを定義
-  本人以外は情報変更できないよう設定

# WHY
- ユーザーが自分の名前とメールアドレスを変更できるようにするため